### PR TITLE
Add an ownerless rules

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 *       @timoschinkel
 **/*test** @schinkel
 **/foo  @hansdubois
+docs/test.md


### PR DESCRIPTION
Ownerless rules seem to be used to exclude a previously owned file.